### PR TITLE
Fix ImageMagick and add Deno for yt-dlp

### DIFF
--- a/.github/workflows/nvg-windowsdx.yml
+++ b/.github/workflows/nvg-windowsdx.yml
@@ -35,6 +35,26 @@ jobs:
           Move-Item "yt-dlp.exe" "baseroot\bin\" -Force
 
       # -----------------------------
+      # Download Deno
+      # -----------------------------
+      - name: Download Deno
+        uses: robinraju/release-downloader@v1
+        with:
+          repository: "denoland/deno"
+          latest: true
+          fileName: "deno-x86_64-pc-windows-msvc.zip"
+
+      - name: Extract Deno
+        run: |
+          $zip = Get-ChildItem -Filter "deno-x86_64-pc-windows-msvc.zip" | Select-Object -First 1
+          if (-not $zip) { throw "Deno download failed" }
+          Expand-Archive $zip.FullName -DestinationPath deno
+
+      - name: Move Deno
+        run: |
+          Move-Item "deno\deno.exe" "baseroot\bin\" -Force
+
+      # -----------------------------
       # Download ImageMagick
       # -----------------------------
       - name: Download ImageMagick

--- a/LINUX_BUILD_INSTRUCTIONS.md
+++ b/LINUX_BUILD_INSTRUCTIONS.md
@@ -16,6 +16,7 @@ The following instructions are for building **Nonsensical Video Generator** from
     - [ffmpeg-release-full.7z (gyan.dev)](https://www.gyan.dev/ffmpeg/builds/)
     - [frei0r-*-win64.7z](https://github.com/dyne/frei0r/releases)
     - [yt-dlp.exe](https://github.com/yt-dlp/yt-dlp/releases)
+    - [deno-x86_64-pc-windows-msvc.zip](https://github.com/denoland/deno/releases)
     - [vocoder-*-x86-win32.zip](https://borsboom.io/vocoder/)
 
 - Setup:
@@ -71,6 +72,7 @@ The following instructions are for building **Nonsensical Video Generator** from
     - Extract `ffmpeg.exe` and `ffprobe.exe` from `ffmpeg-release-full.7z` into `baseroot/bin/`
     - Extract all `.dll` files from `filter/` in `frei0r-*-win64.7z` into `baseroot/bin/frei0r-1` (create the directory if it doesn't exist)
     - Copy `yt-dlp.exe` into `baseroot/bin/`
+    - Extract `deno.exe` from `deno-x86_64-pc-windows-msvc.zip` into `baseroot/bin/`
     - Extract `vocoder.exe` from `vocoder-*-x86-win32.zip` into `baseroot/bin/`
     - Run `dotnet restore` inside of the root directory to install dependencies
 - Building:

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ The following instructions are for building **Nonsensical Video Generator** from
     - [ffmpeg-release-full.7z (gyan.dev)](https://www.gyan.dev/ffmpeg/builds/)
     - [frei0r-*-win64.7z](https://github.com/dyne/frei0r/releases)
     - [yt-dlp.exe](https://github.com/yt-dlp/yt-dlp/releases)
+    - [deno-x86_64-pc-windows-msvc.zip](https://github.com/denoland/deno/releases)
     - [vocoder-*-x86-win32.zip](https://borsboom.io/vocoder/)
 - Setup:
     - Clone this repository to `C:\NVGDev\NVGMonoGame` using these commands:
@@ -36,6 +37,7 @@ The following instructions are for building **Nonsensical Video Generator** from
     - Extract `ffmpeg.exe` and `ffprobe.exe` from `ffmpeg-release-full.7z` into `baseroot/bin/`
     - Extract all `.dll` files from `filter/` in `frei0r-*-win64.7z` into `baseroot/bin/frei0r-1` (create the directory if it doesn't exist)
     - Copy `yt-dlp.exe` into `baseroot/bin/`
+    - Extract `deno.exe` from `deno-x86_64-pc-windows-msvc.zip` into `baseroot/bin/`
     - Extract `vocoder.exe` from `vocoder-*-x86-win32.zip` into `baseroot/bin/`
     - Run `dotnet restore` inside of the root directory to install dependencies
     - Copy `cred.template.bat` in the root directory

--- a/baseplugins/user/distort/distort.lua
+++ b/baseplugins/user/distort/distort.lua
@@ -61,7 +61,7 @@ function StartGeneration(options, pluginSettings, functions)
         distortmusic = functions.getRandomLibraryFile("audio", "distort")
         -- Apply effect
         if functions.magickInstalled() then
-            functions.runMagick("convert -size " .. options.width .. "x" .. options.height .. " canvas:black " .. black)
+            functions.runMagick("-size " .. options.width .. "x" .. options.height .. " canvas:black " .. black)
         else
             -- one frame
             if isnvgupdated then
@@ -80,7 +80,7 @@ function PostCommand(commandindex, outputresult, errorresult, options, pluginSet
         distortmusic = functions.getRandomLibraryFile("audio", "distort")
         -- Apply effect
         if functions.magickInstalled() then
-            functions.runMagick("convert -size " .. options.width .. "x" .. options.height .. " canvas:black " .. black)
+            functions.runMagick("-size " .. options.width .. "x" .. options.height .. " canvas:black " .. black)
         else
             -- one frame
             if isnvgupdated then
@@ -119,7 +119,7 @@ function PostCommand(commandindex, outputresult, errorresult, options, pluginSet
                 functions.setStatusText("Distort: " .. actionreadable .. "ing... (" .. (commandindex - indexoffset) .. "/6)")
             end
             print("Distort: " .. actionreadable .. "ing... (" .. (commandindex - indexoffset) .. "/6)")
-            functions.runMagick("convert \"" .. distort0 .. "\" " .. action .. " \"" .. distorts[commandindex - 1 - indexoffset] .. "\"")
+            functions.runMagick("\"" .. distort0 .. "\" " .. action .. " \"" .. distorts[commandindex - 1 - indexoffset] .. "\"")
         else
             if rng <= 2 then
                 action = "-vf hflip"
@@ -141,7 +141,7 @@ function PostCommand(commandindex, outputresult, errorresult, options, pluginSet
             functions.runFFmpeg("-i \"" .. distort0 .. "\" " .. action .. " -frames:v 1 -update 1 -preset veryfast -y \"" .. distorts[commandindex - 1 - indexoffset] .. "\"")
         end
     elseif commandindex == 7+indexoffset then
-        -- convert mp3 to wav
+        -- mp3 to wav
         functions.runFFmpeg("-i \"" .. distortmusic .. "\" -acodec pcm_s16le -ac 2 -ar 44100 -af \"aresample=async=1000\" -y \"" .. music .. "\"")
     elseif commandindex == 8+indexoffset then
         -- 0 duration = 0.533 seconds

--- a/baseroot/Deno-LICENSE.txt
+++ b/baseroot/Deno-LICENSE.txt
@@ -1,0 +1,20 @@
+MIT License
+
+Copyright 2018-2026 the Deno authors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/baseroot/credits.json
+++ b/baseroot/credits.json
@@ -34,6 +34,7 @@
         "Sdcb.FFmpeg (GPL-3.0 License)",
         "FFmpeg (GPL-3.0 License)",
         "yt-dlp (The Unlicense)",
+        "Deno (MIT License)",
         "ImageMagick (Custom License)"
     ],
     "FontLicense": [

--- a/src/data/BlogData.cs
+++ b/src/data/BlogData.cs
@@ -10,10 +10,10 @@ namespace NonsensicalVideoGenerator
         public static readonly int MinorUpcoming = 8;
         public static readonly int MajorUpcoming = 3;
         public static readonly int Month = 4;
-        public static readonly int Day = 16;
+        public static readonly int Day = 21;
         public static readonly int Year = 2026;
         public static readonly int Tier = 1; // 0: Upcoming, 1: Minor Update, 2: Major Update
-        public static readonly string PostId = "000000000000000000"; // Fill in with update post ID before publishing the build
+        public static readonly string PostId = "685251502317503745"; // Fill in with update post ID before publishing the build
         public static List<string> Subtitle { get; set; } = new List<string>()
         {
             "v%version%",
@@ -24,10 +24,10 @@ namespace NonsensicalVideoGenerator
         {
             // "WWWWWWWWWWWWWWWWWWWWWWWWWWWW"
             "- Updated dependencies",
-            "- Fixed yt-dlp search bug",
+            "- Add Deno to fix silent yt-dlp",
+            "- Fixed yt-dlp directory bug",
             "- Added addon ability for",
             "several random library files",
-            " ",
             " ",
             " ",
             "%footer%"

--- a/src/data/LibraryData.cs
+++ b/src/data/LibraryData.cs
@@ -604,7 +604,15 @@ namespace NonsensicalVideoGenerator
                         path = Path.Combine(libraryRootPath, libraryPaths[downloadType], "%(title)s.%(ext)s");
                         string ytdlp = Global.useSystemYtDlp ? "yt-dlp" : @".\bin\yt-dlp.exe";
                         bool sound = downloadType.RootType == LibraryRootType.Audio;
-                        ProcessStartInfo startInfo = new ProcessStartInfo(ytdlp, "-o \"" + path + "\" " + (sound ? "--extract-audio --audio-format mp3 " : "--format mp4 ") + downloadUrl);
+                        // Switching from --format mp4 to -t mp4 in yt-dlp to suppress the following warning:
+                        /*
+                        WARNING: "-f mp4" selects the best pre-merged mp4 format which is often not what's intended.
+                                Pre-merged mp4 formats are not available from all sites, or may only be available in lower quality.
+                                To prioritize the best h264 video and aac audio in an mp4 container, use "-t mp4" instead.
+                                If you know what you are doing and want a pre-merged mp4 format, use "-f b[ext=mp4]" instead to suppress this warning
+                        */
+                        // Specifying where deno.exe is because it's inside of bin instead of the NVG's root directory
+                        ProcessStartInfo startInfo = new ProcessStartInfo(ytdlp, "--js-runtimes deno:.\\bin\\deno.exe -o \"" + path + "\" " + (sound ? "--extract-audio --audio-format mp3 " : "-t mp4 ") + downloadUrl);
                         startInfo.UseShellExecute = false;
                         startInfo.RedirectStandardOutput = true;
                         startInfo.RedirectStandardError = true;

--- a/src/data/PluginHandler.cs
+++ b/src/data/PluginHandler.cs
@@ -470,7 +470,14 @@ namespace NonsensicalVideoGenerator
         public static void RunMagick(string args)
         {
             if (!ValidateInput(args)) return;
-            PluginHandler.commands.Add(new Command(CommandType.Magick, ReplacePlaceholders(args), jobDirectory));
+            // ImageMagick v7 deprecates the "convert" syntax (magick.exe convert ...)
+            // Because addons were written with the "convert" syntax, we need to truncate it for compatibility
+            string magickArgs = ReplacePlaceholders(args);
+            if (magickArgs.StartsWith("convert "))
+            {
+                magickArgs = magickArgs.Substring(8); // Remove "convert " from the beginning of the arguments
+            }
+            PluginHandler.commands.Add(new Command(CommandType.Magick, magickArgs, jobDirectory));
         }
         // RunVocoder for lua
         public static void RunVocoder(string args)

--- a/src/data/PluginHandler.cs
+++ b/src/data/PluginHandler.cs
@@ -244,7 +244,15 @@ namespace NonsensicalVideoGenerator
                     // Download YouTube video
                     string ytdlp = Global.useSystemYtDlp ? "yt-dlp" : @".\bin\yt-dlp.exe";
                     bool sound = rootType == "audio";
-                    ProcessStartInfo startInfo = new ProcessStartInfo(ytdlp, "-o \"" + combinedPath + "\" " + (sound ? "--extract-audio --audio-format mp3 " : "--format mp4 ") + url)
+                    // Switching from --format mp4 to -t mp4 in yt-dlp to suppress the following warning:
+                    /*
+                    WARNING: "-f mp4" selects the best pre-merged mp4 format which is often not what's intended.
+                            Pre-merged mp4 formats are not available from all sites, or may only be available in lower quality.
+                            To prioritize the best h264 video and aac audio in an mp4 container, use "-t mp4" instead.
+                            If you know what you are doing and want a pre-merged mp4 format, use "-f b[ext=mp4]" instead to suppress this warning
+                    */
+                    // Specifying where deno.exe is because it's inside of bin instead of the NVG's root directory
+                    ProcessStartInfo startInfo = new ProcessStartInfo(ytdlp, "--js-runtimes deno:.\\bin\\deno.exe -o \"" + combinedPath + "\" " + (sound ? "--extract-audio --audio-format mp3 " : "-t mp4 ") + url)
                     {
                         UseShellExecute = false,
                         RedirectStandardOutput = true,
@@ -799,7 +807,14 @@ namespace NonsensicalVideoGenerator
         public static void RunMagickSync(string args)
         {
             if (!ValidateInput(args)) return;
-            new Command(CommandType.Magick, ReplacePlaceholders(args), jobDirectory).Call();
+            // ImageMagick v7 deprecates the "convert" syntax (magick.exe convert ...)
+            // Because addons were written with the "convert" syntax, we need to truncate it for compatibility
+            string magickArgs = ReplacePlaceholders(args);
+            if (magickArgs.StartsWith("convert "))
+            {
+                magickArgs = magickArgs.Substring(8); // Remove "convert " from the beginning of the arguments
+            }
+            new Command(CommandType.Magick, magickArgs, jobDirectory).Call();
         }
         // RunVocoderSync for lua
         public static void RunVocoderSync(string args)

--- a/update.md
+++ b/update.md
@@ -1,10 +1,11 @@
-<@&958798488139890688> There's a [new update](<https://store.steampowered.com/news/app/2516360/view/000000000000000000>) for **Nonsensical Video Generator**:
+<@&958798488139890688> There's a [new update](<https://store.steampowered.com/news/app/2516360/view/685251502317503745>) for **Nonsensical Video Generator**:
 > ## April 2026: Update v8.3
 > Here are the changes in this update:
 > - Updated ffmpeg, ffprobe, frei0r, yt-dlp, and ImageMagick
+> - Add Deno as a new dependency to fix yt-dlp (silent audio bug)
 > - Fixed bug that looked for yt-dlp in the wrong place
 > - Added the ability for addons to get several random library files of the same type
 > Let me know if you have any issues with this update through the <#873289037186748437> channel.
 > Also, please help translate NVG into your language on [GitHub](<https://github.com/NVGPartners/NonsensicalVideoGenerator/wiki/Localization>)!
 > Happy generating! :nonsensicalvideogenerator:
-<https://store.steampowered.com/news/app/2516360/view/000000000000000000>
+<https://store.steampowered.com/news/app/2516360/view/685251502317503745>

--- a/update.txt
+++ b/update.txt
@@ -1,9 +1,10 @@
-April 2026: Update v8.3.1
+April 2026: Update v8.3
 
 Here are the changes in this update:
 
 [list]
 [*]Updated ffmpeg, ffprobe, frei0r, yt-dlp, and ImageMagick
+[*]Add Deno as a new dependency to fix yt-dlp (silent audio bug)
 [*]Fixed bug that looked for yt-dlp in the wrong place
 [*]Added the ability for addons to get several random library files of the same type
 [/list]


### PR DESCRIPTION
ImageMagick v7 no longer allows for `magick.exe convert ...` syntax on Windows.

I corrected the syntax in the Distort effect but there may be older addons that still depend on it, so I wrote a fix that removes "convert " from ImageMagick function arguments.

This fixes an issue where addons using ImageMagick simply didn't work anymore.
```csharp
// RunMagick for lua
public static void RunMagick(string args)
{
    if (!ValidateInput(args)) return;
    // ImageMagick v7 deprecates the "convert" syntax (magick.exe convert ...)
    // Because addons were written with the "convert" syntax, we need to truncate it for compatibility
    string magickArgs = ReplacePlaceholders(args);
    if (magickArgs.StartsWith("convert "))
    {
        magickArgs = magickArgs.Substring(8); // Remove "convert " from the beginning of the arguments
    }
    PluginHandler.commands.Add(new Command(CommandType.Magick, magickArgs, jobDirectory));
}
```
yt-dlp now requires a JavaScript runtime in order to download from YouTube properly, see: https://github.com/yt-dlp/yt-dlp/issues/15012

I added [Deno](https://github.com/denoland/deno) as a new dependency to address this issue, it's now included with NVG.

Also, I changed `--format mp4` to `-t mp4`.

These fix an issue where yt-dlp would download videos with silent audio.
```csharp
// Switching from --format mp4 to -t mp4 in yt-dlp to suppress the following warning:
/*
WARNING: "-f mp4" selects the best pre-merged mp4 format which is often not what's intended.
        Pre-merged mp4 formats are not available from all sites, or may only be available in lower quality.
        To prioritize the best h264 video and aac audio in an mp4 container, use "-t mp4" instead.
        If you know what you are doing and want a pre-merged mp4 format, use "-f b[ext=mp4]" instead to suppress this warning
*/
// Specifying where deno.exe is because it's inside of bin instead of the NVG's root directory
ProcessStartInfo startInfo = new ProcessStartInfo(ytdlp, "--js-runtimes deno:.\\bin\\deno.exe -o \"" + path + "\" " + (sound ? "--extract-audio --audio-format mp3 " : "-t mp4 ") + downloadUrl);
```
I also prepared the Blog data and other files to include a hidden Steam partner news post ID for when this update gets published on the `public` branch.

The instructions and GitHub Actions workflow files now support the new Deno dependency.